### PR TITLE
Add Difficulty to Block Summary and fix a few typos

### DIFF
--- a/lib/blocks.js
+++ b/lib/blocks.js
@@ -360,6 +360,7 @@ BlockController.prototype._getBlockSummary = function(hash, moreTimestamp, next)
                 size: block.size,
                 hash: block.hash,
                 time: block.time,
+                difficulty: block.header.getDifficulty(),
                 txlength: block.tx.length,
                 poolInfo: self.getPoolInfo(spoolAddress),
                 isMainChain: (block.confirmations !== -1)

--- a/services/MarketsService.js
+++ b/services/MarketsService.js
@@ -36,11 +36,11 @@ MarketsService.prototype._updateInfo = function () {
     }, function (err, response, body) {
 
         if (err) {
-            return self.common.log.error('Coingecko error', err);
+            return self.common.log.error('Coinpaprika error', err);
         }
 
         if (response.statusCode != 200) {
-            return self.common.log.error('Coingecko error status code', response.statusCode);
+            return self.common.log.error('Coinpaprika error status code', response.statusCode);
         }
 
         if (body) {
@@ -60,7 +60,7 @@ MarketsService.prototype._updateInfo = function () {
             return self.info;
         }
 
-        return self.common.log.error('Coingecko error body', body);
+        return self.common.log.error('Coinpaprika error body', body);
 
     });
 


### PR DESCRIPTION
Having Difficulty in Block summary would be very useful for developers to use that data for whatever app they may want to build. Currently we have to hit different endpoints to get Difficulty and it is not provided based on Block history.